### PR TITLE
.Jar Workaround code

### DIFF
--- a/MilitaryCalculator.java
+++ b/MilitaryCalculator.java
@@ -19,8 +19,8 @@ import javax.swing.JTextField;
 public class MilitaryCalculator extends JFrame implements ActionListener {
 
 	ResultHelper resultHelper;
-	private static final String VICTORY_RESULT_PATH = "src/com/empire/victory_results.txt"; //Remember to delete "src/" before exporting!
-	private static final String TIE_RESULT_PATH = "src/com/empire/tie_results.txt";
+	private static final String VICTORY_RESULT_PATH = "victory_results.txt";
+	private static final String TIE_RESULT_PATH = "tie_results.txt";
 	private static final String WINNER_TAG = "<WINNER>";
 	private static final String LOSER_TAG = "<LOSER>";
 


### PR DESCRIPTION
Temporary workaround for the .jar file. Will not be merged - will close when the [.jar file path issue](https://github.com/Minescratcher452/empire-mil-calc/issues/5) is fixed.

Place the `victory_results.txt` and `tie-results.txt` files in the same folder as `E4_Mil_calc.jar`.